### PR TITLE
Update CDS URLs

### DIFF
--- a/heat_wave_hazard_assessment_euroheat.ipynb
+++ b/heat_wave_hazard_assessment_euroheat.ipynb
@@ -29,7 +29,7 @@
    "id": "db47b670-7787-4523-803f-a00da6602d22",
    "metadata": {},
    "source": [
-    "The heatwave hazard assessment presented in this page is directly based on an existing [dataset of heat wave days on CDS](https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=overview). You can also view these results directly on the CDS using an [application](https://cds.climate.copernicus.eu/cdsapp#!/software/app-health-heat-waves-projections?tab=app) that shows aggregated results for the NUTS3 administrative regions. This notebook provides an example on how to extract this data for any grid cell of the dataset (resolution of 12 x 12km) in the EU. \n",
+    "The heatwave hazard assessment presented in this page is directly based on an existing [dataset of heat wave days on CDS](https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=overview). You can also view these results directly on the CDS using an [application](https://cds.climate.copernicus.eu/cdsapp#!/software/app-health-heat-waves-projections?tab=app) that shows aggregated results for the NUTS3 administrative regions. This notebook provides an example on how to extract this data for any grid cell of the dataset (resolution of 12 x 12km) in the EU.\n",
     "\n",
     "Methodology is based on the EuroHEAT project ([source](https://confluence.ecmwf.int/display/CKB/Heat+waves+and+cold+spells+in+Europe+derived+from+climate+projections+documentation)) with two options for defining heatwaves:\n",
     " - **Health-related EU-wide definition:** for the summer period of June to August, heat waves were defined as days in which the maximum apparent temperature (Tappmax) exceeds the threshold (90th percentile of Tappmax for each month) and the minimum temperature (Tmin) exceeds its threshold (90th percentile of Tmin for each month) for at least two days. The apparent temperature is a measure of relative discomfort due to combined heat and high humidity, developed based on physiological studies on evaporative skin cooling. It can be calculated as a combination of air and dew point temperature.\n",
@@ -71,7 +71,7 @@
     ":class: hint dropdown\n",
     "* [zipfile](https://docs.python.org/3/library/zipfile.html) - Provides tools for creating, reading, writing, and extracting ZIP files.\n",
     "* [os](https://docs.python.org/3/library/os.html) - Provides functions for interacting with the operating system, such as file and directory manipulation.\n",
-    "* [cdsapi](https://cds.climate.copernicus.eu/api-how-to) - A library to request data from the datasets listed in the CDS catalogue.\n",
+    "* [cdsapi](https://cds-beta.climate.copernicus.eu/how-to-api) - A library to request data from the datasets listed in the CDS catalogue.\n",
     "* [numpy](https://numpy.org/doc/stable/) - A powerful library for numerical computations in Python, widely used for array operations and mathematical functions.\n",
     "* [xarray](https://docs.xarray.dev/en/stable/) - Introduces labels in the form of dimensions, coordinates, and attributes on top of raw NumPy-like arrays for a more intuitive experience.\n",
     "* [rasterio](https://rasterio.readthedocs.io/en/latest/) - A library for reading and writing geospatial raster data.\n",
@@ -162,7 +162,7 @@
    "id": "5e3a7fa3-3ff4-4963-890a-2daf2b5872c4",
    "metadata": {},
    "source": [
-    "- You can download data from the CDS with the API. If this is the first time you do this, you will need to register on CDS and set your API key. Check [[How to change your API KEY](https://cds.climate.copernicus.eu/api-how-to)] and change the KEY in the code cell below.\n"
+    "- You can download data from the CDS with the API. If this is the first time you do this, you will need to register on CDS and set your API key. Check [[How to change your API KEY](https://cds-beta.climate.copernicus.eu/how-to-api)] and change the KEY in the code cell below.\n"
    ]
   },
   {
@@ -172,8 +172,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "URL = \"https://cds.climate.copernicus.eu/api/v2\"\n",
-    "KEY = '' # put here your key!\n",
+    "URL = \"https://cds-beta.climate.copernicus.eu/api\"\n",
+    "KEY = None # put here your key!\n",
     "\n",
     "c = cdsapi.Client(url=URL, key=KEY)"
    ]
@@ -183,7 +183,7 @@
    "id": "64a27fb8-8937-4a9a-8c66-1791087df74b",
    "metadata": {},
    "source": [
-    "#### Downloading the health-related dataset from EuroHEAT [[source](https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=form)]"
+    "#### Downloading the health-related dataset from EuroHEAT [[source](https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=download)]"
    ]
   },
   {
@@ -191,23 +191,7 @@
    "execution_count": 5,
    "id": "b69ea094-82ac-4cb7-8a04-95fd509ef4ca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 10:44:11,971 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 10:44:11,974 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 10:44:11,976 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/sis-heat-and-cold-spells\n",
-      "2024-08-02 10:44:12,362 INFO Request is completed\n",
-      "2024-08-02 10:44:12,367 INFO Downloading https://download-0011-clone.copernicus-climate.eu/cache-compute-0011/cache/data2/dataset-sis-heat-and-cold-spells-42b29473-4537-4689-8f6a-70afdcb8abf3.zip to Heatwave_hazard_EuroHEAT\\data\\heat_spells_health_1986_2085.zip (161.4M)\n",
-      "2024-08-02 10:44:59,876 INFO Download rate 3.4M/s  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'heat_spells_health_1986_2085.zip')\n",
@@ -241,7 +225,7 @@
    "id": "92af4728-991a-4672-8b1c-b9113cc4c21d",
    "metadata": {},
    "source": [
-    "#### Heat wave data based on National definitions from EuroHEAT [[source](https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=form)]"
+    "#### Heat wave data based on National definitions from EuroHEAT [[source](https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=download)]"
    ]
   },
   {
@@ -249,22 +233,7 @@
    "execution_count": 6,
    "id": "6fdbf730-a95e-4c8a-aa4a-c0b6e84becc3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 10:45:06,987 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 10:45:06,990 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 10:45:06,994 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/sis-heat-and-cold-spells\n",
-      "2024-08-02 10:45:07,185 INFO Downloading https://download-0017.copernicus-climate.eu/cache-compute-0017/cache/data1/dataset-sis-heat-and-cold-spells-4540582f-231f-4dbb-bd54-3dc7ceb6e36a.zip to Heatwave_hazard_EuroHEAT\\data\\heat_spells_country_1986_2085.zip (32M)\n",
-      "2024-08-02 10:45:22,136 INFO Download rate 2.1M/s   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'heat_spells_country_1986_2085.zip')\n",

--- a/heat_wave_hazard_assessment_pesetaiv.ipynb
+++ b/heat_wave_hazard_assessment_pesetaiv.ipynb
@@ -66,7 +66,7 @@
     "* [glob](https://docs.python.org/3/library/glob.html) - Unix style pathname pattern expansion.\n",
     "* [itertools](https://docs.python.org/3/library/itertools.html) - Functions for creating iterators forefficient looping.\n",
     "* [rasterio](https://rasterio.readthedocs.io/en/latest/) - A library for reading and writing geospatial raster data.\n",
-    "* [cdsapi](https://cds.climate.copernicus.eu/api-how-to) - A library to request data from the datasets listed in the CDS catalogue.\n",
+    "* [cdsapi](https://cds-beta.climate.copernicus.eu/how-to-api) - A library to request data from the datasets listed in the CDS catalogue.\n",
     "* [numpy](https://numpy.org/doc/stable/) - A powerful library for numerical computations in Python, widely used for array operations and mathematical functions.\n",
     "* [xarray](https://docs.xarray.dev/en/stable/) - Introduces labels in the form of dimensions, coordinates, and attributes on top of raw NumPy-like arrays for a more intuitive experience.\n",
     "* [dask](https://docs.dask.org/en/stable/index.html) - Efficient handling of large datasets and computations.\n",
@@ -171,7 +171,7 @@
    "source": [
     "We need to download the daily maximum air temperature at 2m height from the EURO-CORDEX dataset. The code below will download this data for the selected period and RCP scenario.\n",
     "- In the code below you can find information about selected locations, resolutions, models, periods, etc.\n",
-    "- More information about the **data** you can find [here](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form)\n",
+    "- More information about the **data** you can find [here](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=overview)\n",
     "- More information about **RCP** scenarios can be found [here](https://en.wikipedia.org/wiki/Representative_Concentration_Pathway)"
    ]
   },
@@ -180,17 +180,17 @@
    "id": "28cc01f8",
    "metadata": {},
    "source": [
-    "We can download data from the CDS with the API. If this is the first time you do this, you will need to register on CDS and set your API key. Check [[How to change your API KEY](https://cds.climate.copernicus.eu/api-how-to)] and change the KEY in the code cell below."
+    "We can download data from the CDS with the API. If this is the first time you do this, you will need to register on CDS and set your API key. Check [[How to change your API KEY](https://cds-beta.climate.copernicus.eu/how-to-api)] and change the KEY in the code cell below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "c9eecec7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "URL = \"https://cds.climate.copernicus.eu/api/v2\"\n",
+    "URL = \"https://cds-beta.climate.copernicus.eu/api\"\n",
     "KEY = None # put your key here\n",
     "\n",
     "c = cdsapi.Client(url=URL, key=KEY)"
@@ -201,7 +201,7 @@
    "id": "1a4344e4",
    "metadata": {},
    "source": [
-    "**Important:** we will only download data for a single combination of GCM and RCM models. Below you can specify which combination you would like to use. For a more reliable result of the assessment, it is recommended to make the analysis for several combinations of GCM-RCM. For an overview of available combinations see the [CDS download form](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form) and [documentation on GCM-RCM models](https://confluence.ecmwf.int/display/CKB/CORDEX%3A+Regional+climate+projections#heading-DrivingGlobalClimateModelsandRegionalClimateModels)."
+    "**Important:** we will only download data for a single combination of GCM and RCM models. Below you can specify which combination you would like to use. For a more reliable result of the assessment, it is recommended to make the analysis for several combinations of GCM-RCM. For an overview of available combinations see the [CDS download form](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=download) and [documentation on GCM-RCM models](https://confluence.ecmwf.int/display/CKB/CORDEX%3A+Regional+climate+projections#heading-DrivingGlobalClimateModelsandRegionalClimateModels)."
    ]
   },
   {
@@ -228,21 +228,7 @@
    "execution_count": 9,
    "id": "123c4ad4-ac89-42f8-9e50-c1b40b98eb92",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-06-28 16:16:20,286 INFO Welcome to the CDS\n",
-      "2024-06-28 16:16:20,287 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-06-28 16:16:20,428 INFO Request is queued\n",
-      "2024-06-28 16:16:21,500 INFO Request is running\n",
-      "2024-06-28 16:28:39,913 INFO Request is completed\n",
-      "2024-06-28 16:28:39,963 INFO Downloading https://download-0014-clone.copernicus-climate.eu/cache-compute-0014/cache/data7/dataset-projections-cordex-domains-single-levels-bbd1da20-9898-4bce-91cb-bada1af556a2.zip to Heatwave_hazard_PesetaIV\\data/era5_daily_t2m_eurminmax_1971_2000.zip (3.9G)\n",
-      "2024-06-28 16:38:21,672 INFO Download rate 6.9M/s   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurminmax_1971_2000.zip')\n",
@@ -291,21 +277,7 @@
    "execution_count": null,
    "id": "5147a3f4-e570-4113-a868-3f241e9008fe",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-07-08 18:35:04,354 INFO Welcome to the CDS\n",
-      "2024-07-08 18:35:04,355 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-07-08 18:35:04,504 INFO Request is queued\n",
-      "2024-07-08 18:35:05,543 INFO Request is running\n",
-      "2024-07-08 18:59:24,066 INFO Request is completed\n",
-      "2024-07-08 18:59:24,105 INFO Downloading https://download-0015-clone.copernicus-climate.eu/cache-compute-0015/cache/data1/dataset-projections-cordex-domains-single-levels-aa2ecfc6-66d3-4f75-ab1d-638ac263d8fd.zip to Heatwave_hazard_PesetaIV\\data/era5_daily_t2m_eurminmax_2011_2100.zip (11.7G)\n",
-      " 17%|█████████████▏                                                               | 2.01G/11.7G [08:07<35:32, 4.89MB/s]"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurminmax_2011_2100.zip')\n",
@@ -353,31 +325,7 @@
    "execution_count": 4,
    "id": "1fdf8bfa-e434-4a72-a866-5c77f04cdc0d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-07-09 15:13:19,632 INFO Welcome to the CDS\n",
-      "2024-07-09 15:13:19,642 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-07-09 15:13:19,968 INFO Request is queued\n",
-      "2024-07-09 15:13:21,038 INFO Request is running\n",
-      "2024-07-09 15:51:42,960 INFO Request is completed\n",
-      "2024-07-09 15:51:43,082 INFO Downloading https://download-0018.copernicus-climate.eu/cache-compute-0018/cache/data2/dataset-projections-cordex-domains-single-levels-ddc2627b-2129-46a2-afe9-b91a75c2ed0f.zip to Heatwave_hazard_PesetaIV\\data/era5_daily_t2m_eurmax_rcp45_2011_2100.zip (11.7G)\n",
-      "2024-07-09 16:33:59,797 INFO Download rate 4.7M/s     \n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Result(content_length=12592570100,content_type=application/zip,location=https://download-0018.copernicus-climate.eu/cache-compute-0018/cache/data2/dataset-projections-cordex-domains-single-levels-ddc2627b-2129-46a2-afe9-b91a75c2ed0f.zip)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmax_rcp45_2011_2100.zip')\n",

--- a/heat_wave_hazard_assessment_xclim.ipynb
+++ b/heat_wave_hazard_assessment_xclim.ipynb
@@ -64,7 +64,7 @@
     "* [zipfile](https://docs.python.org/3/library/zipfile.html) - Working with ZIP archive files (compression and extraction).\n",
     "* [os](https://docs.python.org/3/library/os.html) - Interacting with the operating system, including handling the current working directory.\n",
     "* [rasterio](https://rasterio.readthedocs.io/en/latest/) - Reading and writing geospatial raster data.\n",
-    "* [cdsapi](https://cds.climate.copernicus.eu/api-how-to) - Interacting with the Climate Data Store (CDS) API for downloading climate data.\n",
+    "* [cdsapi](https://cds-beta.climate.copernicus.eu/how-to-api) - Interacting with the Climate Data Store (CDS) API for downloading climate data.\n",
     "* [numpy](https://numpy.org/doc/stable/) - Handling large, multi-dimensional arrays and matrices, along with a collection of mathematical functions to operate on these arrays.\n",
     "* [xarray](https://docs.xarray.dev/en/stable/) - Handling labeled multi-dimensional arrays, commonly used for 2D and 3D array data handling.\n",
     "* [dask](https://docs.dask.org/en/stable/index.html) - Efficient handling of large datasets and computations.\n",
@@ -161,7 +161,7 @@
    "id": "5e3a7fa3-3ff4-4963-890a-2daf2b5872c4",
    "metadata": {},
    "source": [
-    "You can download data from the CDS with the API - look at [[How to change your API KEY](https://cds.climate.copernicus.eu/api-how-to)] and change the KEY below for authentication.\n"
+    "You can download data from the CDS with the API - look at [[How to change your API KEY](https://cds-beta.climate.copernicus.eu/how-to-api)] and change the KEY below for authentication.\n"
    ]
   },
   {
@@ -171,8 +171,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "URL = \"https://cds.climate.copernicus.eu/api/v2\"\n",
-    "KEY = \"\" # put your key here\n",
+    "URL = \"https://cds-beta.climate.copernicus.eu/api\"\n",
+    "KEY = None # put your key here\n",
     "\n",
     "c = cdsapi.Client(url=URL, key=KEY)"
    ]
@@ -184,7 +184,7 @@
    "source": [
     "We need to download the daily maximum and daily minimum air temperature at 2m height from the EURO-CORDEX dataset. The code below will download this data for the selected period and RCP scenario.\n",
     "- In the code below you can find information about selected locations, resolutions, models, periods, etc.\n",
-    "- More information about the **data** you can find [here](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form)\n",
+    "- More information about the **data** you can find [here](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=overview)\n",
     "- More information about **RCP** scenarios can be found [here](https://en.wikipedia.org/wiki/Representative_Concentration_Pathway)"
    ]
   },
@@ -193,7 +193,7 @@
    "id": "dac7c4fa",
    "metadata": {},
    "source": [
-    "**Important:** we will only download data for a single combination of GCM and RCM models. Below you can specify which combination you would like to use. For a more reliable result of the assessment, it is recommended to make the analysis for several combinations of GCM-RCM. For an overview of available combinations see the [CDS download form](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form) and [documentation on GCM-RCM models](https://confluence.ecmwf.int/display/CKB/CORDEX%3A+Regional+climate+projections#heading-DrivingGlobalClimateModelsandRegionalClimateModels)."
+    "**Important:** we will only download data for a single combination of GCM and RCM models. Below you can specify which combination you would like to use. For a more reliable result of the assessment, it is recommended to make the analysis for several combinations of GCM-RCM. For an overview of available combinations see the [CDS download form](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=download) and [documentation on GCM-RCM models](https://confluence.ecmwf.int/display/CKB/CORDEX%3A+Regional+climate+projections#heading-DrivingGlobalClimateModelsandRegionalClimateModels)."
    ]
   },
   {
@@ -220,25 +220,7 @@
    "execution_count": 6,
    "id": "123c4ad4-ac89-42f8-9e50-c1b40b98eb92",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 10:45:44,042 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 10:45:44,042 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 10:45:44,043 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-08-02 10:45:44,164 INFO Request is queued\n",
-      "2024-08-02 10:45:45,200 INFO Request is running\n",
-      "2024-08-02 11:02:02,953 INFO Request is completed\n",
-      "2024-08-02 11:02:02,954 INFO Downloading https://download-0006-clone.copernicus-climate.eu/cache-compute-0006/cache/data2/dataset-projections-cordex-domains-single-levels-dd80da57-5457-4122-aa1d-660a4eac45ff.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurmax_1971_2005.zip (4.6G)\n",
-      "2024-08-02 11:21:56,753 INFO Download rate 3.9M/s    \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmax_1971_2005.zip')\n",
@@ -286,25 +268,7 @@
    "execution_count": 7,
    "id": "20f3cb31-8d00-45e9-a6c8-d366072b4713",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 11:22:05,134 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 11:22:05,135 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 11:22:05,136 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-08-02 11:22:05,277 INFO Request is queued\n",
-      "2024-08-02 11:22:06,315 INFO Request is running\n",
-      "2024-08-02 11:34:24,118 INFO Request is completed\n",
-      "2024-08-02 11:34:24,120 INFO Downloading https://download-0001-clone.copernicus-climate.eu/cache-compute-0001/cache/data7/dataset-projections-cordex-domains-single-levels-e64812fc-d862-4e75-9033-78bb93d10269.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurmin_1971_2005.zip (4.5G)\n",
-      "2024-08-02 11:51:37,470 INFO Download rate 4.5M/s    \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmin_1971_2005.zip')\n",
@@ -354,31 +318,7 @@
    "execution_count": 8,
    "id": "5147a3f4-e570-4113-a868-3f241e9008fe",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 11:51:45,597 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 11:51:45,598 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 11:51:45,599 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 11:51:45,736 INFO Request is queued\n",
-      "2024-08-02 11:51:46,777 INFO Request is running\n",
-      "2024-08-02 12:06:04,593 INFO Request is completed\n",
-      "2024-08-02 12:06:04,593 INFO Downloading https://download-0011-clone.copernicus-climate.eu/cache-compute-0011/cache/data6/dataset-projections-cordex-domains-single-levels-7e8dc0c2-ca79-4102-9fab-8aff2b95633c.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurminmax_2006_2100.zip (5.9G)\n",
-      "2024-08-02 12:14:02,618 INFO Download rate 12.5M/s   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurminmax_2006_2100.zip')\n",
@@ -426,25 +366,7 @@
    "execution_count": 9,
    "id": "599ec6c0-118c-43ae-bfc3-ef52218209e6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 12:14:12,636 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 12:14:12,637 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 12:14:12,638 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-08-02 12:14:12,756 INFO Request is queued\n",
-      "2024-08-02 12:14:13,796 INFO Request is running\n",
-      "2024-08-02 12:34:31,938 INFO Request is completed\n",
-      "2024-08-02 12:34:31,939 INFO Downloading https://download-0012-clone.copernicus-climate.eu/cache-compute-0012/cache/data4/dataset-projections-cordex-domains-single-levels-0d2e0d50-257f-4ddb-972d-73f7c65e875d.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurmin_2006_2100.zip (5.8G)\n",
-      "2024-08-02 12:41:12,994 INFO Download rate 14.9M/s   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmin_2006_2100.zip')\n",
@@ -492,25 +414,7 @@
    "execution_count": 10,
    "id": "1fdf8bfa-e434-4a72-a866-5c77f04cdc0d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 12:41:22,942 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 12:41:22,943 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 12:41:22,944 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-08-02 12:41:23,075 INFO Request is queued\n",
-      "2024-08-02 12:41:24,110 INFO Request is running\n",
-      "2024-08-02 12:53:41,643 INFO Request is completed\n",
-      "2024-08-02 12:53:41,645 INFO Downloading https://download-0003-clone.copernicus-climate.eu/cache-compute-0003/cache/data3/dataset-projections-cordex-domains-single-levels-ac74c5eb-8965-4959-b61a-557a579c7370.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurmax_rcp45_2006_2100.zip (5.9G)\n",
-      "2024-08-02 13:03:59,997 INFO Download rate 9.7M/s   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmax_rcp45_2006_2100.zip')\n",
@@ -560,25 +464,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-08-02 13:04:11,011 INFO Welcome to the CDS.\n",
-      " As per our announcements on the Forum, this instance of CDS will soon be decommissioned.\n",
-      " Please update your cdsapi package to a version >=0.7.0, create an account on CDS-Beta and update your .cdsapirc file. We strongly recommend users to check our Guidelines at https://confluence.ecmwf.int/x/uINmFw\n",
-      " The current legacy system will be kept for a while, but we will reduce resources gradually until full decommissioning in September 2024.\n",
-      "2024-08-02 13:04:11,012 WARNING MOVE TO CDS-Beta\n",
-      "2024-08-02 13:04:11,013 INFO Sending request to https://cds.climate.copernicus.eu/api/v2/resources/projections-cordex-domains-single-levels\n",
-      "2024-08-02 13:04:11,124 INFO Request is queued\n",
-      "2024-08-02 13:04:12,163 INFO Request is running\n",
-      "2024-08-02 13:20:29,977 INFO Request is completed\n",
-      "2024-08-02 13:20:29,978 INFO Downloading https://download-0014-clone.copernicus-climate.eu/cache-compute-0014/cache/data8/dataset-projections-cordex-domains-single-levels-2bb29c8e-ef19-4db9-b650-e7fc0d039253.zip to Heatwave_hazard_XCLIM\\data\\eurocordex_daily_t2m_eurmin_rcp45_2006_2100.zip (5.8G)\n",
-      "2024-08-02 13:25:26,009 INFO Download rate 20.2M/s  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define zip file's absolute path\n",
     "zip_path = os.path.join(data_dir, 'eurocordex_daily_t2m_eurmin_rcp45_2006_2100.zip')\n",
@@ -5913,7 +5799,7 @@
     "\n",
     "- Copernicus Climate Data Store, heatwave days and heat-related mortality for nine European cities (2021), https://cds.climate.copernicus.eu/cdsapp#!/software/app-health-urban-heat-related-mortality-projections?tab=app [2024-06-17].\n",
     "\n",
-    "- Copernicus Climate Data Store, heatwaves and cold spells in Europe derived from climate projections (2019), https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=overview [2024-06-17].\n",
+    "- Copernicus Climate Data Store, heatwaves and cold spells in Europe derived from climate projections (2019), https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=overview [2024-06-17].\n",
     "\n",
     "- Climate adapt, Apparent temperature heatwave days (2021), https://climate-adapt.eea.europa.eu/en/metadata/indicators/apparent-temperature-heatwave-days [2024-06-17].\n",
     "\n",

--- a/heat_wave_risk_description.md
+++ b/heat_wave_risk_description.md
@@ -39,12 +39,12 @@ In the CLIMAAX workflow (in the following pages) we demonstrate how EURO-CORDEX 
 
 We use the climate scenarios RCP4.5 (medium) and RCP8.5 (extreme) to compare the effect of different climate scenarios ([more about RCPs](https://en.wikipedia.org/wiki/Representative_Concentration_Pathway)).
 
-As a result of the hazard assessment, we can obtain information about the heatwave frequency of occurrence in the reference period of 1971-2000 and three future periods: 2011-2040, 2041-2070 and 2071-2100. This result is based on model data for climate projections. 
+As a result of the hazard assessment, we can obtain information about the heatwave frequency of occurrence in the reference period of 1971-2000 and three future periods: 2011-2040, 2041-2070 and 2071-2100. This result is based on model data for climate projections.
 
 ##### Source datasets in this workflow
- Xclim methodology in this workflow uses the [EURO-CORDEX data](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form).
+ Xclim methodology in this workflow uses the [EURO-CORDEX data](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=overview).
 
-Heatwave data prepared by the EuroHEAT project is directly available from the [dedicated dataset](https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=form) on the Copernicus Data Store. This data is also based on EURO-CORDEX data.
+Heatwave data prepared by the EuroHEAT project is directly available from the [dedicated dataset](https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=overview) on the Copernicus Data Store. This data is also based on EURO-CORDEX data.
 
 Both methodologies are thus based on the EURO-CORDEX climate projections data. Please note that the resolution of this data is 12x12km, and it is not suitable for accurately evaluating heat wave risks inside cities, because the dataset does not take into account the urban heat-island effect.
 
@@ -91,9 +91,9 @@ Natalia Aleksandrova, Deltares.
 
 Euroheat: 11.6.2024 [[source](https://confluence.ecmwf.int/display/CKB/Heat+waves+and+cold+spells+in+Europe+derived+from+climate+projections+documentation#heading-3References)]
 
-Peseta IV: 11.6.2024 [[source](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form)]
+Peseta IV: 11.6.2024 [[source](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=overview)]
 
-XCLIM: 11.6.2024 [[source](https://cds.climate.copernicus.eu/cdsapp#!/dataset/projections-cordex-domains-single-levels?tab=form)]
+XCLIM: 11.6.2024 [[source](https://cds-beta.climate.copernicus.eu/datasets/projections-cordex-domains-single-levels?tab=overview)]
 
 RSLAB, Land surface Temperature, based on the Landsat8 imagery: 11.6.2024 [[source](https://rslab.gr/Landsat_LST.html)]
 

--- a/heatwave_risk_projections.ipynb
+++ b/heatwave_risk_projections.ipynb
@@ -61,7 +61,7 @@
     "* [glob](https://docs.python.org/3/library/glob.html) - Unix style pathname pattern expansion.\n",
     "* [pathlib](https://docs.python.org/3/library/pathlib.html) - File system paths.\n",
     "* [geopandas](https://geopandas.org/en/stable/) - Geospatial data handling.\n",
-    "* [cdsapi](https://cds.climate.copernicus.eu/api-how-to) - Climate Data Store API.\n",
+    "* [cdsapi](https://cds-beta.climate.copernicus.eu/how-to-api) - Climate Data Store API.\n",
     "* [xarray](https://docs.xarray.dev/en/stable/) - 2-3D array data handling.\n",
     "* [rasterio](https://rasterio.readthedocs.io/en/latest/) - NetCDF and raster processing.\n",
     "* [numpy](https://numpy.org/doc/stable/) - 2-3D array data handling.\n",
@@ -243,8 +243,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "URL = \"https://cds.climate.copernicus.eu/api/v2\"\n",
-    "KEY = \"\" ### put here your key!!!"
+    "URL = \"https://cds-beta.climate.copernicus.eu/api\"\n",
+    "KEY = None ### put here your key!!!"
    ]
   },
   {
@@ -1268,7 +1268,7 @@
     "  \n",
     "- Climate adapt, EuroHEATonline heat-wave forecast (2007), https://climate-adapt.eea.europa.eu/en/metadata/tools/euroheat-online-heatwave-forecast [2024-06-17]\n",
     "  \n",
-    "- Copernicus Climate Data Store, Heat waves and cold spells in Europe derived from climate projections (2019), https://cds.climate.copernicus.eu/cdsapp#!/dataset/sis-heat-and-cold-spells?tab=overview [2024-06-17].\n",
+    "- Copernicus Climate Data Store, Heat waves and cold spells in Europe derived from climate projections (2019), https://cds-beta.climate.copernicus.eu/datasets/sis-heat-and-cold-spells?tab=overview [2024-06-17].\n",
     "  \n",
     "- GADM, shapefiles of the European regions (2018), https://gadm.org/download_country.html#google_vignette [2024-06-20]"
    ]


### PR DESCRIPTION
Hello @MartinKAJO,

The commit updates all dataset and API URLs to use the new CDS beta. The current (old) CDS is being shut down in September.

I've left the URLs to CDS applications for now. While the Applications feature is still around in the new CDS (https://cds-beta.climate.copernicus.eu/applications), the number of available applications is strongly reduced. I'm afraid that if the linked applications get removed in September, we'll have to remove the links to them here as well.

- Christopher