### PR TITLE
Don't write population raster stack before summing and clip with bbox

### DIFF
--- a/01_Urban_heatwaves/heatwave_risk_projected_change_Catalunya_example.ipynb
+++ b/01_Urban_heatwaves/heatwave_risk_projected_change_Catalunya_example.ipynb
@@ -879,40 +879,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "fcb57142-ee95-4075-9b67-db6cd10465ab",
+   "execution_count": 15,
+   "id": "47dfabce-10d8-4539-9f47-aa2652a23595",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load all population data files\n",
-    "poplist = glob.glob(f'{data_dir}/population/*.tif')\n",
+    "# Open all downloaded population files\n",
+    "pop = xr.open_mfdataset(\n",
+    "    os.path.join(data_dir, \"population\", '*.tif'),\n",
+    "    chunks=\"auto\",\n",
+    "    concat_dim=\"band\",\n",
+    "    combine=\"nested\"\n",
+    ")\n",
     "\n",
-    "# Open the first raster to get the metadata\n",
-    "with rasterio.open(poplist[0]) as src0:\n",
-    "    meta = src0.meta\n",
-    "\n",
-    "# Update metadata to match the number of layers, compression, and data type\n",
-    "meta.update(count=len(poplist), compress='lzw', dtype=src0.dtypes[0])\n",
-    "\n",
-    "# Create the output raster stack with updated metadata\n",
-    "with rasterio.open(f'{data_dir}/Population_raster_stack.tif', 'w', **meta) as dst:\n",
-    "    for id, layer in enumerate(poplist, start=1):\n",
-    "        with rasterio.open(layer) as src1:\n",
-    "            dst.write_band(id, src1.read(1))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "a674ed2c-bb7d-4799-a7a5-859c293b1ea4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pop_path = f'{data_dir}/Population_raster_stack.tif'\n",
-    "pop = xr.open_dataset(pop_path)\n",
-    "pop = pop.sum(dim='band', skipna=True, keep_attrs=True)\n",
-    "pop = pop['band_data']\n",
-    "pop.rio.to_raster(raster_path=f'{data_dir}/pop_sum.tif')"
+    "# Cut to the region of interest based on the provided shapefile\n",
+    "pop = pop.rio.clip_box(*gdf.total_bounds, crs=gdf.crs)\n",
+    "# Sum over all files at every gridpoint\n",
+    "pop = pop.sum(dim=\"band\", skipna=True, keep_attrs=True)\n",
+    "# Write summed vulnerable population to disk\n",
+    "pop[\"band_data\"].rio.to_raster(raster_path=f'{data_dir}/pop_sum.tif')"
    ]
   },
   {


### PR DESCRIPTION
Reduces disk space requirements as the `Population_raster_stack.tif` is never created and the `pop_sum.tif` file is clipped.